### PR TITLE
Set package-ecosystem to 'github-actions' in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
This pull request adds a configuration file for Dependabot to automate updates for GitHub Actions workflows. The configuration schedules weekly checks for updates.

Dependency management:

* Added `.github/dependabot.yml` to enable Dependabot version updates for GitHub Actions, with a weekly update schedule.