### PR TITLE
Fix npm cache warning by using action path

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -25,10 +25,12 @@ runs:
       with:
         node-version: '18'
         cache: 'npm'
+        cache-dependency-path: ${{ github.action_path }}/package-lock.json
 
     - name: Install dependencies
       shell: bash
       run: npm ci
+      working-directory: ${{ github.action_path }}
 
     - name: Run PR analysis
       shell: bash
@@ -38,9 +40,11 @@ runs:
         ANALYZE_ALL_REPOS: ${{ inputs.analyze_all_repos }}
         CLEAN_CACHE: ${{ inputs.clean_cache }}
       run: npm run analyze
+      working-directory: ${{ github.action_path }}
 
     - name: Generate Mermaid Charts
       shell: bash
       env:
         GITHUB_TOKEN: ${{ inputs.github_token }}
       run: npm run charts
+      working-directory: ${{ github.action_path }}


### PR DESCRIPTION
## Problem

When using the action, a warning appears during the post-job cleanup:

```
Warning: Path Validation Error: Path(s) specified in the action for caching do(es) not exist, hence no cache is being saved.
```

This happens because `actions/setup-node@v4` with `cache: 'npm'` looks for `package-lock.json` in the consuming repository's working directory, but the action's dependencies are in the action's own directory.

## Solution

Use `github.action_path` to reference the action's directory:

1. **cache-dependency-path**: Point to the action's `package-lock.json`
2. **working-directory**: Run all npm commands from the action's directory

This ensures npm operations and caching work from the correct location.

## Changes

```yaml
- name: Set up Node.js
  uses: actions/setup-node@v4
  with:
    node-version: '18'
    cache: 'npm'
    cache-dependency-path: ${{ github.action_path }}/package-lock.json

- name: Install dependencies
  shell: bash
  run: npm ci
  working-directory: ${{ github.action_path }}

- name: Run PR analysis
  shell: bash
  run: npm run analyze
  working-directory: ${{ github.action_path }}

- name: Generate Mermaid Charts
  shell: bash
  run: npm run charts
  working-directory: ${{ github.action_path }}
```

## Testing

- [ ] Verify no cache warning appears
- [ ] Confirm npm dependencies install correctly
- [ ] Validate analysis and charts generate successfully