### PR TITLE
fix: resolve shellcheck SC2086 and SC2129 in example.yml

### DIFF
--- a/.github/workflows/example.yml
+++ b/.github/workflows/example.yml
@@ -73,7 +73,9 @@ jobs:
       - name: Display results summary
         if: always()
         run: |
-          echo "## Analysis Complete! 🎉" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "Analysis results have been uploaded as artifacts." >> $GITHUB_STEP_SUMMARY
-          echo "Check the charts and tables in the step summary above." >> $GITHUB_STEP_SUMMARY
+          {
+            echo "## Analysis Complete! 🎉"
+            echo ""
+            echo "Analysis results have been uploaded as artifacts."
+            echo "Check the charts and tables in the step summary above."
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

Fixes actionlint failures caused by shellcheck warnings in `.github/workflows/example.yml` at the "Display results summary" step.

### Changes

- **SC2129**: Consolidated 4 individual `>> $GITHUB_STEP_SUMMARY` redirects into a single grouped redirect `{ ... } >> "$GITHUB_STEP_SUMMARY"`
- **SC2086**: Quoted `$GITHUB_STEP_SUMMARY` → `"$GITHUB_STEP_SUMMARY"` to prevent globbing/word splitting