### PR TITLE
feat: add Claude and Codex AI agent detection with step summary control

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -20,6 +20,10 @@ inputs:
     description: 'Organizations to skip during analysis. Multiline input with one entry per line. Supports simple format (skip entire org) or selective format (org-name:include:repo1,repo2)'
     required: false
     default: ''
+  output_to_step_summary:
+    description: 'Write analysis results to the GitHub step summary'
+    required: false
+    default: 'true'
 
 runs:
   using: 'composite'
@@ -49,5 +53,6 @@ runs:
       shell: bash
       env:
         GITHUB_TOKEN: ${{ inputs.github_token }}
+        OUTPUT_TO_STEP_SUMMARY: ${{ inputs.output_to_step_summary }}
       run: npm run charts
       working-directory: ${{ github.action_path }}

--- a/src/index.js
+++ b/src/index.js
@@ -90,12 +90,27 @@ async function runAnalysis(options) {
         console.log('\n=== SUMMARY ===');
         console.log(`Total repositories analyzed: [${results.totalRepositories}]`);
         console.log(`Total PRs analyzed: [${results.totalPRs}]`);
+        console.log(`AI-assisted PRs (total): [${results.totalAIAssistedPRs || results.totalCopilotPRs}]`);
         console.log(`Copilot-assisted PRs: [${results.totalCopilotPRs}]`);
+        if (results.totalClaudePRs > 0) {
+            console.log(`Claude-assisted PRs: [${results.totalClaudePRs}]`);
+        }
+        if (results.totalCodexPRs > 0) {
+            console.log(`Codex-assisted PRs: [${results.totalCodexPRs}]`);
+        }
         console.log(`Copilot-triggered Actions runs: [${results.totalActionsRuns}]`);
         console.log(`Copilot Actions minutes used: [${results.totalActionsMinutes}]`);
         if (results.totalPRs > 0) {
             const overallCopilotPercentage = Math.round(results.totalCopilotPRs / results.totalPRs * 100 * 100) / 100;
             console.log(`Overall Copilot Usage on PRs: [${overallCopilotPercentage}]%`);
+            if (results.totalClaudePRs > 0) {
+                const overallClaudePercentage = Math.round(results.totalClaudePRs / results.totalPRs * 100 * 100) / 100;
+                console.log(`Overall Claude Usage on PRs: [${overallClaudePercentage}]%`);
+            }
+            if (results.totalCodexPRs > 0) {
+                const overallCodexPercentage = Math.round(results.totalCodexPRs / results.totalPRs * 100 * 100) / 100;
+                console.log(`Overall Codex Usage on PRs: [${overallCodexPercentage}]%`);
+            }
         }
         
         console.log('\n=== WEEKLY BREAKDOWN ===');

--- a/src/mermaid-generator.js
+++ b/src/mermaid-generator.js
@@ -874,6 +874,36 @@ export function generateSummaryStats(results) {
     if (results.totalCopilotAgentPRs !== undefined) {
         lines.push(`- **Copilot Agent PRs**: ${formatNumberMetric(results.totalCopilotAgentPRs)}`);
     }
+
+    if (results.totalClaudePRs !== undefined && results.totalClaudePRs > 0) {
+        lines.push('');
+        lines.push(`- **Claude-Assisted PRs**: ${formatNumberMetric(results.totalClaudePRs)}`);
+        if (results.totalPRs > 0) {
+            const claudePercentage = Math.round(results.totalClaudePRs / results.totalPRs * 100 * 100) / 100;
+            lines.push(`- **Overall Claude Usage**: ${formatNumberMetric(claudePercentage)}%`);
+        }
+        if (results.totalClaudeReviewPRs !== undefined) {
+            lines.push(`- **Claude Review PRs**: ${formatNumberMetric(results.totalClaudeReviewPRs)}`);
+        }
+        if (results.totalClaudeAgentPRs !== undefined) {
+            lines.push(`- **Claude Agent PRs**: ${formatNumberMetric(results.totalClaudeAgentPRs)}`);
+        }
+    }
+
+    if (results.totalCodexPRs !== undefined && results.totalCodexPRs > 0) {
+        lines.push('');
+        lines.push(`- **Codex-Assisted PRs**: ${formatNumberMetric(results.totalCodexPRs)}`);
+        if (results.totalPRs > 0) {
+            const codexPercentage = Math.round(results.totalCodexPRs / results.totalPRs * 100 * 100) / 100;
+            lines.push(`- **Overall Codex Usage**: ${formatNumberMetric(codexPercentage)}%`);
+        }
+        if (results.totalCodexReviewPRs !== undefined) {
+            lines.push(`- **Codex Review PRs**: ${formatNumberMetric(results.totalCodexReviewPRs)}`);
+        }
+        if (results.totalCodexAgentPRs !== undefined) {
+            lines.push(`- **Codex Agent PRs**: ${formatNumberMetric(results.totalCodexAgentPRs)}`);
+        }
+    }
     
     if (results.totalActionsRuns !== undefined) {
         lines.push(`- **Copilot-triggered Actions runs**: ${formatNumberMetric(results.totalActionsRuns)}`);
@@ -920,8 +950,14 @@ export function generateSummaryStats(results) {
 
 /**
  * Write content to GitHub step summary.
+ * Skips writing if OUTPUT_TO_STEP_SUMMARY is explicitly set to 'false'.
  */
 export async function writeToStepSummary(content) {
+    const outputToStepSummary = process.env.OUTPUT_TO_STEP_SUMMARY;
+    if (outputToStepSummary && outputToStepSummary.toLowerCase() === 'false') {
+        return;
+    }
+
     const stepSummaryFile = process.env.GITHUB_STEP_SUMMARY;
     if (stepSummaryFile) {
         try {

--- a/src/pr-analyzer.js
+++ b/src/pr-analyzer.js
@@ -519,46 +519,55 @@ export class GitHubPRAnalyzer {
     }
 
     /**
-     * Analyze commits in a PR to count commits by user vs Copilot.
+     * Analyze commits in a PR to count commits by user vs AI tool.
      */
     analyzeCommitCounts(commits) {
         let totalCommits = commits.length;
         let userCommits = 0;
         let copilotCommits = 0;
+        let claudeCommits = 0;
+        let codexCommits = 0;
         
         for (const commit of commits) {
-            const author = commit.commit?.author?.name || '';
-            const committer = commit.commit?.committer?.name || '';
+            const author = (commit.commit?.author?.name || '').toLowerCase();
+            const committer = (commit.commit?.committer?.name || '').toLowerCase();
+            const authorLogin = (commit.author?.login || '').toLowerCase();
             const message = (commit.commit?.message || '').toLowerCase();
             
-            // Check if this is a Copilot-assisted commit
             const isCopilotCommit = 
-                // Co-authored by Copilot
-                message.includes('co-authored-by:') && message.includes('copilot') ||
-                // Commit by Copilot
-                author.toLowerCase().includes('copilot') ||
-                committer.toLowerCase().includes('copilot') ||
-                // Commit message mentions Copilot
-                message.includes('copilot');
+                (message.includes('co-authored-by:') && message.includes('copilot')) ||
+                author.includes('copilot') ||
+                committer.includes('copilot') ||
+                authorLogin.includes('copilot');
+
+            // Strong-evidence detection: co-author trailer or bot login (not broad name matching)
+            const isClaudeCommit = !isCopilotCommit && (
+                (message.includes('co-authored-by:') && message.includes('claude')) ||
+                (authorLogin.includes('claude') && authorLogin.includes('[bot]'))
+            );
+
+            const isCodexCommit = !isCopilotCommit && !isClaudeCommit && (
+                (message.includes('co-authored-by:') && message.includes('codex')) ||
+                (authorLogin.includes('codex') && authorLogin.includes('[bot]'))
+            );
             
             if (isCopilotCommit) {
                 copilotCommits++;
+            } else if (isClaudeCommit) {
+                claudeCommits++;
+            } else if (isCodexCommit) {
+                codexCommits++;
             } else {
-                // Check if commit is by the analyzed user
-                const commitAuthor = commit.author?.login || author;
-                if (commitAuthor === this.owner || author.includes(this.owner)) {
-                    userCommits++;
-                } else {
-                    // Count as user commit if not explicitly Copilot-related
-                    userCommits++;
-                }
+                userCommits++;
             }
         }
         
         return {
             totalCommits,
             userCommits,
-            copilotCommits
+            copilotCommits,
+            claudeCommits,
+            codexCommits
         };
     }
 
@@ -590,46 +599,81 @@ export class GitHubPRAnalyzer {
     }
 
     /**
-     * Detect GitHub Copilot collaboration and categorize by assistance type.
+     * Detect AI agent collaboration and categorize by tool and assistance type.
+     * Returns { tool: 'copilot'|'claude'|'codex'|'none', type: 'agent'|'review'|'none' }
      */
     async detectCopilotCollaboration(pr) {
         const title = (pr.title || '').toLowerCase();
         const body = (pr.body || '').toLowerCase();
-        
-        // Priority 1: Check if author is Copilot (highest priority)
-        if (pr.user && pr.user.login && pr.user.login.toLowerCase() === 'copilot') {
-            return 'agent';
+
+        // Helpers: strong-evidence bot identity checks (bot username or [bot] suffix)
+        const isClaudeLogin = (login) => {
+            const l = login.toLowerCase();
+            return l === 'claude' || (l.includes('claude') && l.includes('[bot]'));
+        };
+        const isCodexLogin = (login) => {
+            const l = login.toLowerCase();
+            return l === 'codex' || (l.includes('codex') && l.includes('[bot]'));
+        };
+
+        // Priority 1: Check if author is a known AI bot (highest priority)
+        if (pr.user && pr.user.login) {
+            const authorLogin = pr.user.login.toLowerCase();
+            if (authorLogin === 'copilot') {
+                return { tool: 'copilot', type: 'agent' };
+            }
+            if (isClaudeLogin(pr.user.login)) {
+                return { tool: 'claude', type: 'agent' };
+            }
+            if (isCodexLogin(pr.user.login)) {
+                return { tool: 'codex', type: 'agent' };
+            }
         }
         
-        // Priority 2: Check assignees for Copilot
+        // Priority 2: Check assignees for known AI bots
         if (pr.assignees && Array.isArray(pr.assignees)) {
             for (const assignee of pr.assignees) {
-                if (assignee.login && assignee.login.toLowerCase() === 'copilot') {
-                    return 'agent';
+                if (assignee.login) {
+                    const assigneeLogin = assignee.login.toLowerCase();
+                    if (assigneeLogin === 'copilot') {
+                        return { tool: 'copilot', type: 'agent' };
+                    }
+                    if (isClaudeLogin(assignee.login)) {
+                        return { tool: 'claude', type: 'agent' };
+                    }
+                    if (isCodexLogin(assignee.login)) {
+                        return { tool: 'codex', type: 'agent' };
+                    }
                 }
             }
         }
         
-        // Priority 3: Check reviewers for Copilot-related bots
+        // Priority 3: Check reviewers for AI-related bots
         try {
             const reviews = await this.getPRReviews(pr.base.repo.full_name, pr.number);
             for (const review of reviews) {
                 if (review.user && review.user.login) {
                     const reviewerLogin = review.user.login.toLowerCase();
                     
-                    // Check for specific Copilot reviewer bot
+                    // Copilot reviewer detection
                     if (reviewerLogin === 'copilot-pull-request-reviewer[bot]') {
-                        return 'review';
+                        return { tool: 'copilot', type: 'review' };
                     }
-                    
-                    // Check for general Copilot reviewer patterns
                     if (reviewerLogin.includes('copilot') && reviewerLogin.includes('review')) {
-                        return 'review';
+                        return { tool: 'copilot', type: 'review' };
                     }
-                    
-                    // Check for Copilot as a reviewer
                     if (reviewerLogin === 'copilot') {
-                        return 'review';
+                        return { tool: 'copilot', type: 'review' };
+                    }
+
+                    // Claude reviewer detection
+                    if (isClaudeLogin(review.user.login)) {
+                        return { tool: 'claude', type: 'review' };
+                    }
+
+                    // Codex reviewer detection
+                    if (isCodexLogin(review.user.login)) {
+                        return { tool: 'codex', type: 'review' };
                     }
                 }
             }
@@ -637,32 +681,40 @@ export class GitHubPRAnalyzer {
             console.log(`Warning: Could not fetch reviews for PR #${pr.number}: ${error.message}`);
         }
         
-        // Priority 4: Check commits for Copilot collaboration
+        // Priority 4: Check commits for AI co-author trailers
         try {
             const commits = await this.getPRCommits(pr.base.repo.full_name, pr.number);
             for (const commit of commits) {
                 const message = (commit.commit.message || '').toLowerCase();
                 
-                // Check for co-authored-by with Copilot
+                // Copilot co-author or mention
                 if (message.includes('co-authored-by:') && message.includes('copilot')) {
-                    return 'agent';
+                    return { tool: 'copilot', type: 'agent' };
                 }
-                
-                // Check for Copilot in commit message with context
                 if (message.includes('copilot')) {
                     const reviewPatterns = ['review', 'feedback', 'suggestion', 'comment', 'approve'];
                     if (reviewPatterns.some(pattern => message.includes(pattern))) {
-                        return 'review';
+                        return { tool: 'copilot', type: 'review' };
                     } else {
-                        return 'agent';
+                        return { tool: 'copilot', type: 'agent' };
                     }
+                }
+
+                // Claude co-author trailer (strong evidence only)
+                if (message.includes('co-authored-by:') && message.includes('claude')) {
+                    return { tool: 'claude', type: 'agent' };
+                }
+
+                // Codex co-author trailer (strong evidence only)
+                if (message.includes('co-authored-by:') && message.includes('codex')) {
+                    return { tool: 'codex', type: 'agent' };
                 }
             }
         } catch (error) {
             console.log(`Warning: Could not fetch commits for PR #${pr.number}: ${error.message}`);
         }
         
-        // Priority 5: Check title/body for Copilot keywords
+        // Priority 5: Check title/body for Copilot keywords (Copilot only – avoids false positives for Claude/Codex)
         const copilotKeywords = ['copilot', 'co-pilot', 'github copilot', 'ai-assisted', 'ai assisted'];
         const reviewPatterns = ['review', 'feedback', 'suggestion', 'comment', 'approve'];
         const agentPatterns = ['generate', 'create', 'implement', 'code', 'develop', 'write'];
@@ -672,18 +724,16 @@ export class GitHubPRAnalyzer {
         );
         
         if (copilotMentioned) {
-            // Determine if it's review or agent based on context
             if (reviewPatterns.some(pattern => title.includes(pattern) || body.includes(pattern))) {
-                return 'review';
+                return { tool: 'copilot', type: 'review' };
             } else if (agentPatterns.some(pattern => title.includes(pattern) || body.includes(pattern))) {
-                return 'agent';
+                return { tool: 'copilot', type: 'agent' };
             } else {
-                // Default to agent if Copilot mentioned but no specific context
-                return 'agent';
+                return { tool: 'copilot', type: 'agent' };
             }
         }
         
-        return 'none';
+        return { tool: 'none', type: 'none' };
     }
 
     /**
@@ -740,6 +790,13 @@ export class GitHubPRAnalyzer {
         let totalCopilotPRs = 0;
         let totalCopilotReviewPRs = 0;
         let totalCopilotAgentPRs = 0;
+        let totalClaudePRs = 0;
+        let totalClaudeReviewPRs = 0;
+        let totalClaudeAgentPRs = 0;
+        let totalCodexPRs = 0;
+        let totalCodexReviewPRs = 0;
+        let totalCodexAgentPRs = 0;
+        let totalAIAssistedPRs = 0;
         let totalDependabotPRs = 0;
         let totalRepositories = 0;
         
@@ -833,6 +890,13 @@ export class GitHubPRAnalyzer {
                             copilotAssistedPRs: 0,
                             copilotReviewPRs: 0,
                             copilotAgentPRs: 0,
+                            claudeAssistedPRs: 0,
+                            claudeReviewPRs: 0,
+                            claudeAgentPRs: 0,
+                            codexAssistedPRs: 0,
+                            codexReviewPRs: 0,
+                            codexAgentPRs: 0,
+                            aiAssistedPRs: 0,
                             collaborators: new Set(),
                             repositories: new Set(),
                             pullRequests: []
@@ -873,33 +937,61 @@ export class GitHubPRAnalyzer {
 
                     weeklyData[weekKey].repositories.add(maskedRepoName);
 
-                    // Detect Copilot collaboration
-                    const copilotType = await this.detectCopilotCollaboration(pr);
-                    
-                    let copilotAssisted = false;
-                    if (copilotType === 'review') {
-                        weeklyData[weekKey].copilotReviewPRs++;
-                        totalCopilotReviewPRs++;
-                        copilotAssisted = true;
-                    } else if (copilotType === 'agent') {
-                        weeklyData[weekKey].copilotAgentPRs++;
-                        totalCopilotAgentPRs++;
-                        copilotAssisted = true;
+                    // Detect AI agent collaboration
+                    const aiCollaboration = await this.detectCopilotCollaboration(pr);
+                    const { tool: aiTool, type: aiType } = aiCollaboration;
+                    const aiAssisted = aiType !== 'none';
+                    const copilotAssisted = aiAssisted && aiTool === 'copilot';
+
+                    if (aiType === 'review') {
+                        if (aiTool === 'copilot') {
+                            weeklyData[weekKey].copilotReviewPRs++;
+                            totalCopilotReviewPRs++;
+                        } else if (aiTool === 'claude') {
+                            weeklyData[weekKey].claudeReviewPRs++;
+                            totalClaudeReviewPRs++;
+                        } else if (aiTool === 'codex') {
+                            weeklyData[weekKey].codexReviewPRs++;
+                            totalCodexReviewPRs++;
+                        }
+                    } else if (aiType === 'agent') {
+                        if (aiTool === 'copilot') {
+                            weeklyData[weekKey].copilotAgentPRs++;
+                            totalCopilotAgentPRs++;
+                        } else if (aiTool === 'claude') {
+                            weeklyData[weekKey].claudeAgentPRs++;
+                            totalClaudeAgentPRs++;
+                        } else if (aiTool === 'codex') {
+                            weeklyData[weekKey].codexAgentPRs++;
+                            totalCodexAgentPRs++;
+                        }
                     }
                     
                     if (copilotAssisted) {
                         weeklyData[weekKey].copilotAssistedPRs++;
                         totalCopilotPRs++;
                     }
+                    if (aiTool === 'claude') {
+                        weeklyData[weekKey].claudeAssistedPRs++;
+                        totalClaudePRs++;
+                    }
+                    if (aiTool === 'codex') {
+                        weeklyData[weekKey].codexAssistedPRs++;
+                        totalCodexPRs++;
+                    }
+                    if (aiAssisted) {
+                        weeklyData[weekKey].aiAssistedPRs++;
+                        totalAIAssistedPRs++;
+                    }
                     
-                    // Analyze commit counts for Copilot PRs
+                    // Analyze commit counts for AI-assisted PRs
                     let commitCounts = null;
-                    if (copilotAssisted) {
+                    if (aiAssisted) {
                         try {
                             const commits = await this.getPRCommits(pr.base.repo.full_name, pr.number);
                             commitCounts = this.analyzeCommitCounts(commits);
                         } catch (error) {
-                            console.log(`Warning: Could not analyze commits for Copilot PR #${pr.number}: ${error.message}`);
+                            console.log(`Warning: Could not analyze commits for AI-assisted PR #${pr.number}: ${error.message}`);
                         }
                     }
                     
@@ -920,7 +1012,10 @@ export class GitHubPRAnalyzer {
                         repository: maskedRepoName,
                         createdAt: pr.created_at,
                         copilotAssisted: copilotAssisted,
-                        copilotType: copilotType,
+                        copilotType: copilotAssisted ? aiType : undefined,
+                        aiAssisted: aiAssisted,
+                        aiTool: aiTool,
+                        aiType: aiType,
                         dependabotPr: false, // Always false since we exclude Dependabot PRs
                         url: pr.html_url,
                         collaborators: new Set([
@@ -983,6 +1078,13 @@ export class GitHubPRAnalyzer {
                                     copilotAssistedPRs: 0,
                                     copilotReviewPRs: 0,
                                     copilotAgentPRs: 0,
+                                    claudeAssistedPRs: 0,
+                                    claudeReviewPRs: 0,
+                                    claudeAgentPRs: 0,
+                                    codexAssistedPRs: 0,
+                                    codexReviewPRs: 0,
+                                    codexAgentPRs: 0,
+                                    aiAssistedPRs: 0,
                                     collaborators: new Set(),
                                     repositories: new Set(),
                                     pullRequests: [],
@@ -1034,7 +1136,10 @@ export class GitHubPRAnalyzer {
         console.log('\nAnalysis complete:');
         console.log(`- Total PRs analyzed: ${totalPRs}`);
         console.log(`- Dependabot PRs excluded: ${totalDependabotPRs}`);
-        console.log(`- Copilot-assisted PRs: ${totalCopilotPRs}`);
+        console.log(`- AI-assisted PRs (total): ${totalAIAssistedPRs}`);
+        console.log(`  - Copilot: ${totalCopilotPRs}`);
+        if (totalClaudePRs > 0) console.log(`  - Claude: ${totalClaudePRs}`);
+        if (totalCodexPRs > 0) console.log(`  - Codex: ${totalCodexPRs}`);
         console.log(`- Repositories analyzed: ${totalRepositories}`);
         console.log(`- Copilot-triggered Actions runs: ${totalActionsRuns}`);
         console.log(`- Copilot Actions minutes used: ${totalActionsMinutes}`);
@@ -1045,6 +1150,13 @@ export class GitHubPRAnalyzer {
             const copilotPercentage = data.totalPRs > 0 ? (data.copilotAssistedPRs / data.totalPRs * 100) : 0;
             const copilotReviewPercentage = data.totalPRs > 0 ? (data.copilotReviewPRs / data.totalPRs * 100) : 0;
             const copilotAgentPercentage = data.totalPRs > 0 ? (data.copilotAgentPRs / data.totalPRs * 100) : 0;
+            const claudePercentage = data.totalPRs > 0 ? ((data.claudeAssistedPRs || 0) / data.totalPRs * 100) : 0;
+            const claudeReviewPercentage = data.totalPRs > 0 ? ((data.claudeReviewPRs || 0) / data.totalPRs * 100) : 0;
+            const claudeAgentPercentage = data.totalPRs > 0 ? ((data.claudeAgentPRs || 0) / data.totalPRs * 100) : 0;
+            const codexPercentage = data.totalPRs > 0 ? ((data.codexAssistedPRs || 0) / data.totalPRs * 100) : 0;
+            const codexReviewPercentage = data.totalPRs > 0 ? ((data.codexReviewPRs || 0) / data.totalPRs * 100) : 0;
+            const codexAgentPercentage = data.totalPRs > 0 ? ((data.codexAgentPRs || 0) / data.totalPRs * 100) : 0;
+            const aiPercentage = data.totalPRs > 0 ? ((data.aiAssistedPRs || 0) / data.totalPRs * 100) : 0;
             
             finalWeeklyData[weekKey] = {
                 totalPRs: data.totalPRs,
@@ -1054,6 +1166,20 @@ export class GitHubPRAnalyzer {
                 copilotPercentage: Math.round(copilotPercentage * 100) / 100,
                 copilotReviewPercentage: Math.round(copilotReviewPercentage * 100) / 100,
                 copilotAgentPercentage: Math.round(copilotAgentPercentage * 100) / 100,
+                claudeAssistedPRs: data.claudeAssistedPRs || 0,
+                claudeReviewPRs: data.claudeReviewPRs || 0,
+                claudeAgentPRs: data.claudeAgentPRs || 0,
+                claudePercentage: Math.round(claudePercentage * 100) / 100,
+                claudeReviewPercentage: Math.round(claudeReviewPercentage * 100) / 100,
+                claudeAgentPercentage: Math.round(claudeAgentPercentage * 100) / 100,
+                codexAssistedPRs: data.codexAssistedPRs || 0,
+                codexReviewPRs: data.codexReviewPRs || 0,
+                codexAgentPRs: data.codexAgentPRs || 0,
+                codexPercentage: Math.round(codexPercentage * 100) / 100,
+                codexReviewPercentage: Math.round(codexReviewPercentage * 100) / 100,
+                codexAgentPercentage: Math.round(codexAgentPercentage * 100) / 100,
+                aiAssistedPRs: data.aiAssistedPRs || 0,
+                aiPercentage: Math.round(aiPercentage * 100) / 100,
                 uniqueCollaborators: data.collaborators.size,
                 collaborators: Array.from(data.collaborators),
                 repositories: Array.from(data.repositories),
@@ -1076,6 +1202,13 @@ export class GitHubPRAnalyzer {
             totalCopilotPRs: totalCopilotPRs,
             totalCopilotReviewPRs: totalCopilotReviewPRs,
             totalCopilotAgentPRs: totalCopilotAgentPRs,
+            totalClaudePRs: totalClaudePRs,
+            totalClaudeReviewPRs: totalClaudeReviewPRs,
+            totalClaudeAgentPRs: totalClaudeAgentPRs,
+            totalCodexPRs: totalCodexPRs,
+            totalCodexReviewPRs: totalCodexReviewPRs,
+            totalCodexAgentPRs: totalCodexAgentPRs,
+            totalAIAssistedPRs: totalAIAssistedPRs,
             totalDependabotPRs: totalDependabotPRs,
             totalRepositories: totalRepositories,
             totalActionsMinutes: totalActionsMinutes,
@@ -1109,7 +1242,7 @@ export class GitHubPRAnalyzer {
             if (weekData.pullRequests && weekData.pullRequests.length > 0) {
                 for (const pr of weekData.pullRequests) {
                     const prLink = `[#${pr.number} ${pr.title}](${pr.url})`;
-                    const copilotType = pr.copilotAssisted ? pr.copilotType : 'none';
+                    const aiDisplay = pr.aiAssisted ? `${pr.aiTool}-${pr.aiType}` : 'none';
                     
                     // Calculate line changes
                     const linesChanged = pr.lineChanges ? 
@@ -1122,7 +1255,7 @@ export class GitHubPRAnalyzer {
                     // Get action minutes if available (this might need to be added to the data structure)
                     const actionMinutes = pr.actionMinutes || 'n/a';
                     
-                    textContent += `| ${week} | ${copilotType} | ${prLink} | ${commentsCount} | ${linesChanged} | ${actionMinutes} |\n`;
+                    textContent += `| ${week} | ${aiDisplay} | ${prLink} | ${commentsCount} | ${linesChanged} | ${actionMinutes} |\n`;
                 }
             }
         }
@@ -1423,7 +1556,7 @@ export class GitHubPRAnalyzer {
                     }
 
                     const prLink = `[${prTitle}](${pr.url})`;
-                    const copilotType = pr.copilotAssisted ? pr.copilotType : 'none';
+                    const aiDisplay = pr.aiAssisted ? `${pr.aiTool}-${pr.aiType}` : 'none';
 
                     // Add lines of code changed info
                     let linesChanged = '';
@@ -1433,7 +1566,7 @@ export class GitHubPRAnalyzer {
                         filesChanged = pr.lineChanges.filesChanged.toString();
                     }
 
-                    textContent += `| ${week} | ${copilotType} | ${prLink} | ${linesChanged} | ${filesChanged} |\n`;
+                    textContent += `| ${week} | ${aiDisplay} | ${prLink} | ${linesChanged} | ${filesChanged} |\n`;
                 }
             }
         }

--- a/tests/copilot-detection.test.js
+++ b/tests/copilot-detection.test.js
@@ -70,8 +70,8 @@ describe('GitHubPRAnalyzer - Copilot Detection', () => {
         const result = await analyzer.detectCopilotCollaboration(prData);
         
         // Based on the priority in detectCopilotCollaboration:
-        // 1. Copilot bot as author -> 'agent' (this should match first)
-        expect(result).toBe('agent');
+        // 1. Copilot bot as author -> { tool: 'copilot', type: 'agent' } (this should match first)
+        expect(result).toEqual({ tool: 'copilot', type: 'agent' });
     });
 
     test('should detect Copilot as author as agent', async () => {
@@ -93,7 +93,7 @@ describe('GitHubPRAnalyzer - Copilot Detection', () => {
         jest.spyOn(analyzer, 'getPRCommits').mockResolvedValue([]);
         
         const result = await analyzer.detectCopilotCollaboration(prData);
-        expect(result).toBe('agent');
+        expect(result).toEqual({ tool: 'copilot', type: 'agent' });
     });
 
     test('should detect copilot-pull-request-reviewer[bot] as review', async () => {
@@ -119,7 +119,7 @@ describe('GitHubPRAnalyzer - Copilot Detection', () => {
         jest.spyOn(analyzer, 'getPRCommits').mockResolvedValue([]);
         
         const result = await analyzer.detectCopilotCollaboration(prData);
-        expect(result).toBe('review');
+        expect(result).toEqual({ tool: 'copilot', type: 'review' });
     });
 
     test('should detect Copilot as assignee as agent', async () => {
@@ -141,7 +141,7 @@ describe('GitHubPRAnalyzer - Copilot Detection', () => {
         jest.spyOn(analyzer, 'getPRCommits').mockResolvedValue([]);
         
         const result = await analyzer.detectCopilotCollaboration(prData);
-        expect(result).toBe('agent');
+        expect(result).toEqual({ tool: 'copilot', type: 'agent' });
     });
 
     test('should detect Copilot as reviewer as review', async () => {
@@ -167,7 +167,7 @@ describe('GitHubPRAnalyzer - Copilot Detection', () => {
         jest.spyOn(analyzer, 'getPRCommits').mockResolvedValue([]);
         
         const result = await analyzer.detectCopilotCollaboration(prData);
-        expect(result).toBe('review');
+        expect(result).toEqual({ tool: 'copilot', type: 'review' });
     });
 
     test('should return none for PR without Copilot', async () => {
@@ -189,7 +189,7 @@ describe('GitHubPRAnalyzer - Copilot Detection', () => {
         jest.spyOn(analyzer, 'getPRCommits').mockResolvedValue([]);
         
         const result = await analyzer.detectCopilotCollaboration(prData);
-        expect(result).toBe('none');
+        expect(result).toEqual({ tool: 'none', type: 'none' });
     });
 
     test('should handle edge case reviewer names with copilot and review', async () => {
@@ -215,7 +215,7 @@ describe('GitHubPRAnalyzer - Copilot Detection', () => {
         jest.spyOn(analyzer, 'getPRCommits').mockResolvedValue([]);
         
         const result = await analyzer.detectCopilotCollaboration(prData);
-        expect(result).toBe('review');
+        expect(result).toEqual({ tool: 'copilot', type: 'review' });
     });
 
     test('should not detect usernames containing copilot but not review as reviewers', async () => {
@@ -241,7 +241,7 @@ describe('GitHubPRAnalyzer - Copilot Detection', () => {
         jest.spyOn(analyzer, 'getPRCommits').mockResolvedValue([]);
         
         const result = await analyzer.detectCopilotCollaboration(prData);
-        expect(result).toBe('none');
+        expect(result).toEqual({ tool: 'none', type: 'none' });
     });
 
     test('should detect dependabot PRs', () => {
@@ -265,6 +265,290 @@ describe('GitHubPRAnalyzer - Copilot Detection', () => {
     });
     
     test('should analyze commit counts correctly', () => {
+        const commits = [
+            {
+                commit: {
+                    author: { name: 'rajbos' },
+                    committer: { name: 'GitHub' },
+                    message: 'Add new feature'
+                },
+                author: { login: 'rajbos' }
+            },
+            {
+                commit: {
+                    author: { name: 'GitHub Copilot' },
+                    committer: { name: 'GitHub' },
+                    message: 'Fix bug with copilot assistance'
+                },
+                author: { login: 'rajbos' }
+            },
+            {
+                commit: {
+                    author: { name: 'rajbos' },
+                    committer: { name: 'GitHub' },
+                    message: 'Update README\n\nCo-authored-by: GitHub Copilot <noreply@github.com>'
+                },
+                author: { login: 'rajbos' }
+            },
+            {
+                commit: {
+                    author: { name: 'rajbos' },
+                    committer: { name: 'GitHub' },
+                    message: 'Regular commit without assistance'
+                },
+                author: { login: 'rajbos' }
+            }
+        ];
+        
+        const result = analyzer.analyzeCommitCounts(commits);
+        
+        expect(result.totalCommits).toBe(4);
+        expect(result.copilotCommits).toBe(2); // One with Copilot author, one with co-authored-by
+        expect(result.userCommits).toBe(2); // Two regular commits
+        expect(result.claudeCommits).toBe(0);
+        expect(result.codexCommits).toBe(0);
+    });
+    
+    test('should handle empty commit list', () => {
+        const result = analyzer.analyzeCommitCounts([]);
+        
+        expect(result.totalCommits).toBe(0);
+        expect(result.userCommits).toBe(0);
+        expect(result.copilotCommits).toBe(0);
+        expect(result.claudeCommits).toBe(0);
+        expect(result.codexCommits).toBe(0);
+    });
+    
+    test('should detect copilot commits by author name', () => {
+        const commits = [
+            {
+                commit: {
+                    author: { name: 'copilot[bot]' },
+                    committer: { name: 'GitHub' },
+                    message: 'Generated code'
+                },
+                author: { login: 'copilot[bot]' }
+            }
+        ];
+        
+        const result = analyzer.analyzeCommitCounts(commits);
+        
+        expect(result.totalCommits).toBe(1);
+        expect(result.copilotCommits).toBe(1);
+        expect(result.userCommits).toBe(0);
+    });
+
+    test('should detect Claude commits by co-authored-by trailer', () => {
+        const commits = [
+            {
+                commit: {
+                    author: { name: 'rajbos' },
+                    committer: { name: 'GitHub' },
+                    message: 'Add feature\n\nCo-authored-by: Claude <claude@anthropic.com>'
+                },
+                author: { login: 'rajbos' }
+            }
+        ];
+        
+        const result = analyzer.analyzeCommitCounts(commits);
+        
+        expect(result.totalCommits).toBe(1);
+        expect(result.claudeCommits).toBe(1);
+        expect(result.copilotCommits).toBe(0);
+        expect(result.userCommits).toBe(0);
+    });
+
+    test('should detect Codex commits by co-authored-by trailer', () => {
+        const commits = [
+            {
+                commit: {
+                    author: { name: 'rajbos' },
+                    committer: { name: 'GitHub' },
+                    message: 'Add feature\n\nCo-authored-by: Codex <codex@openai.com>'
+                },
+                author: { login: 'rajbos' }
+            }
+        ];
+        
+        const result = analyzer.analyzeCommitCounts(commits);
+        
+        expect(result.totalCommits).toBe(1);
+        expect(result.codexCommits).toBe(1);
+        expect(result.copilotCommits).toBe(0);
+        expect(result.userCommits).toBe(0);
+    });
+
+    test('should detect Claude[bot] as PR author (agent)', async () => {
+        const prData = {
+            number: 10,
+            title: 'Fix authentication bug',
+            body: 'Fixed the login issue.',
+            user: { login: 'claude[bot]', type: 'Bot' },
+            assignees: [],
+            requested_reviewers: [],
+            base: { repo: { full_name: 'test/repo' } }
+        };
+
+        jest.spyOn(analyzer, 'getPRReviews').mockResolvedValue([]);
+        jest.spyOn(analyzer, 'getPRCommits').mockResolvedValue([]);
+
+        const result = await analyzer.detectCopilotCollaboration(prData);
+        expect(result).toEqual({ tool: 'claude', type: 'agent' });
+    });
+
+    test('should detect claude-ai[bot] as PR assignee (agent)', async () => {
+        const prData = {
+            number: 11,
+            title: 'Refactor module',
+            body: 'Cleaned up the code.',
+            user: { login: 'human_user', type: 'User' },
+            assignees: [{ login: 'claude-ai[bot]', type: 'Bot' }],
+            requested_reviewers: [],
+            base: { repo: { full_name: 'test/repo' } }
+        };
+
+        jest.spyOn(analyzer, 'getPRReviews').mockResolvedValue([]);
+        jest.spyOn(analyzer, 'getPRCommits').mockResolvedValue([]);
+
+        const result = await analyzer.detectCopilotCollaboration(prData);
+        expect(result).toEqual({ tool: 'claude', type: 'agent' });
+    });
+
+    test('should detect claude[bot] as reviewer (review)', async () => {
+        const prData = {
+            number: 12,
+            title: 'Add new endpoint',
+            body: 'Adds /health endpoint.',
+            user: { login: 'human_user', type: 'User' },
+            assignees: [],
+            requested_reviewers: [],
+            base: { repo: { full_name: 'test/repo' } }
+        };
+
+        const mockReviews = [
+            { user: { login: 'claude[bot]', type: 'Bot' } }
+        ];
+
+        jest.spyOn(analyzer, 'getPRReviews').mockResolvedValue(mockReviews);
+        jest.spyOn(analyzer, 'getPRCommits').mockResolvedValue([]);
+
+        const result = await analyzer.detectCopilotCollaboration(prData);
+        expect(result).toEqual({ tool: 'claude', type: 'review' });
+    });
+
+    test('should detect Claude via co-authored-by commit trailer (agent)', async () => {
+        const prData = {
+            number: 13,
+            title: 'Update dependencies',
+            body: 'Updated packages.',
+            user: { login: 'human_user', type: 'User' },
+            assignees: [],
+            requested_reviewers: [],
+            base: { repo: { full_name: 'test/repo' } }
+        };
+
+        const mockCommits = [
+            {
+                commit: {
+                    message: 'Update deps\n\nCo-authored-by: Claude <noreply@anthropic.com>',
+                    author: { name: 'human_user' },
+                    committer: { name: 'GitHub' }
+                },
+                author: { login: 'human_user' }
+            }
+        ];
+
+        jest.spyOn(analyzer, 'getPRReviews').mockResolvedValue([]);
+        jest.spyOn(analyzer, 'getPRCommits').mockResolvedValue(mockCommits);
+
+        const result = await analyzer.detectCopilotCollaboration(prData);
+        expect(result).toEqual({ tool: 'claude', type: 'agent' });
+    });
+
+    test('should detect codex[bot] as PR author (agent)', async () => {
+        const prData = {
+            number: 14,
+            title: 'Implement sorting algorithm',
+            body: 'Added quicksort.',
+            user: { login: 'codex[bot]', type: 'Bot' },
+            assignees: [],
+            requested_reviewers: [],
+            base: { repo: { full_name: 'test/repo' } }
+        };
+
+        jest.spyOn(analyzer, 'getPRReviews').mockResolvedValue([]);
+        jest.spyOn(analyzer, 'getPRCommits').mockResolvedValue([]);
+
+        const result = await analyzer.detectCopilotCollaboration(prData);
+        expect(result).toEqual({ tool: 'codex', type: 'agent' });
+    });
+
+    test('should detect Codex via co-authored-by commit trailer (agent)', async () => {
+        const prData = {
+            number: 15,
+            title: 'Add tests',
+            body: 'Added unit tests.',
+            user: { login: 'human_user', type: 'User' },
+            assignees: [],
+            requested_reviewers: [],
+            base: { repo: { full_name: 'test/repo' } }
+        };
+
+        const mockCommits = [
+            {
+                commit: {
+                    message: 'Add tests\n\nCo-authored-by: Codex <noreply@openai.com>',
+                    author: { name: 'human_user' },
+                    committer: { name: 'GitHub' }
+                },
+                author: { login: 'human_user' }
+            }
+        ];
+
+        jest.spyOn(analyzer, 'getPRReviews').mockResolvedValue([]);
+        jest.spyOn(analyzer, 'getPRCommits').mockResolvedValue(mockCommits);
+
+        const result = await analyzer.detectCopilotCollaboration(prData);
+        expect(result).toEqual({ tool: 'codex', type: 'agent' });
+    });
+
+    test('should not detect a human user named claude as Claude bot', async () => {
+        const prData = {
+            number: 16,
+            title: 'Fix null pointer',
+            body: 'Fixes issue.',
+            user: { login: 'claude-smith', type: 'User' },
+            assignees: [],
+            requested_reviewers: [],
+            base: { repo: { full_name: 'test/repo' } }
+        };
+
+        jest.spyOn(analyzer, 'getPRReviews').mockResolvedValue([]);
+        jest.spyOn(analyzer, 'getPRCommits').mockResolvedValue([]);
+
+        const result = await analyzer.detectCopilotCollaboration(prData);
+        expect(result).toEqual({ tool: 'none', type: 'none' });
+    });
+
+    test('should not false-positive on PR title containing "claude" without bot evidence', async () => {
+        const prData = {
+            number: 17,
+            title: 'Integrate Claude API for chatbot',
+            body: 'Added Claude Sonnet integration.',
+            user: { login: 'human_user', type: 'User' },
+            assignees: [],
+            requested_reviewers: [],
+            base: { repo: { full_name: 'test/repo' } }
+        };
+
+        jest.spyOn(analyzer, 'getPRReviews').mockResolvedValue([]);
+        jest.spyOn(analyzer, 'getPRCommits').mockResolvedValue([]);
+
+        const result = await analyzer.detectCopilotCollaboration(prData);
+        expect(result).toEqual({ tool: 'none', type: 'none' });
+    });
+    
+    test('should analyze line changes correctly', () => {
         const commits = [
             {
                 commit: {

--- a/tests/step-summary.test.js
+++ b/tests/step-summary.test.js
@@ -1,4 +1,5 @@
-import { generateSummaryStats, generateRepositoryDataTable, generateActionsMinutesChart, generateActionsMinutesDataTable, formatNumberMetric } from '../src/mermaid-generator.js';
+import { jest } from '@jest/globals';
+import { generateSummaryStats, generateRepositoryDataTable, generateActionsMinutesChart, generateActionsMinutesDataTable, formatNumberMetric, writeToStepSummary } from '../src/mermaid-generator.js';
 
 describe('Step Summary Integration', () => {
     describe('formatNumberMetric', () => {
@@ -37,6 +38,12 @@ describe('Step Summary Integration', () => {
                 totalCopilotPRs: 30,
                 totalCopilotReviewPRs: 20,
                 totalCopilotAgentPRs: 10,
+                totalClaudePRs: 5,
+                totalClaudeReviewPRs: 2,
+                totalClaudeAgentPRs: 3,
+                totalCodexPRs: 3,
+                totalCodexReviewPRs: 1,
+                totalCodexAgentPRs: 2,
                 totalActionsRuns: 15,
                 totalActionsMinutes: 120,
                 weeklyAnalysis: {}
@@ -53,6 +60,16 @@ describe('Step Summary Integration', () => {
             expect(summary).toContain('**Copilot-Assisted PRs**: 30');
             expect(summary).toContain('**Copilot Review PRs**: 20');
             expect(summary).toContain('**Copilot Agent PRs**: 10');
+
+            // Verify Claude data is included
+            expect(summary).toContain('**Claude-Assisted PRs**: 5');
+            expect(summary).toContain('**Claude Review PRs**: 2');
+            expect(summary).toContain('**Claude Agent PRs**: 3');
+
+            // Verify Codex data is included
+            expect(summary).toContain('**Codex-Assisted PRs**: 3');
+            expect(summary).toContain('**Codex Review PRs**: 1');
+            expect(summary).toContain('**Codex Agent PRs**: 2');
         });
 
         test('should handle missing Actions data gracefully', () => {
@@ -287,6 +304,38 @@ describe('Step Summary Integration', () => {
             // Verify metric notation with dot as thousand separator
             expect(table).toContain('| 2023-W01 | 810 | 101.891 |');
             expect(table).toContain('| **Total** | **810** | **101.891** |');
+        });
+    });
+
+    describe('writeToStepSummary - output_to_step_summary control', () => {
+        const originalEnv = process.env;
+
+        afterEach(() => {
+            process.env = { ...originalEnv };
+        });
+
+        test('should skip writing when OUTPUT_TO_STEP_SUMMARY is false', async () => {
+            process.env.OUTPUT_TO_STEP_SUMMARY = 'false';
+            process.env.GITHUB_STEP_SUMMARY = undefined;
+            // Capture console output to verify nothing was written
+            const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+            
+            await writeToStepSummary('test content');
+            
+            expect(consoleSpy).not.toHaveBeenCalledWith('test content');
+            consoleSpy.mockRestore();
+        });
+
+        test('should write to console when GITHUB_STEP_SUMMARY is not set and OUTPUT_TO_STEP_SUMMARY is not false', async () => {
+            delete process.env.OUTPUT_TO_STEP_SUMMARY;
+            delete process.env.GITHUB_STEP_SUMMARY;
+            
+            const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+            
+            await writeToStepSummary('step summary content');
+            
+            expect(consoleSpy).toHaveBeenCalledWith('step summary content');
+            consoleSpy.mockRestore();
         });
     });
 });


### PR DESCRIPTION
## Summary

Extends the PR analysis tool to detect Claude (Anthropic) and Codex (OpenAI) AI agents in pull requests, alongside the existing GitHub Copilot detection. Also adds a new `output_to_step_summary` parameter to control whether results are written to the GitHub step summary.

## Changes

### AI Agent Detection (Claude & Codex)
- **Strong-evidence-only detection**: bot login patterns (`claude[bot]`, `codex[bot]`, etc.) and `co-authored-by:` commit trailers — no false positives from keywords in PR titles/bodies
- `detectCopilotCollaboration()` return type changed from `string` to `{ tool, type }` object
- Detects Claude/Codex as PR author, assignee, reviewer, or via commit co-author trailers
- New aggregate counters: `totalClaudePRs`, `totalClaudeReviewPRs`, `totalClaudeAgentPRs`, `totalCodexPRs`, `totalCodexReviewPRs`, `totalCodexAgentPRs`, `totalAIAssistedPRs`
- Per-PR fields: `aiAssisted`, `aiTool`, `aiType`
- **Backward compatible**: `copilotAssisted` and `copilotType` fields preserved on all PR details

### Commit Detection
- `analyzeCommitCounts()` now returns `claudeCommits` and `codexCommits` counts
- Detects Claude/Codex commits via `co-authored-by:` trailer in commit messages

### Step Summary Control
- New `output_to_step_summary` input in root `action.yml` (default: `'true'`)
- `writeToStepSummary()` skips output when `OUTPUT_TO_STEP_SUMMARY=false`

### Output / Charts
- `generateSummaryStats()` conditionally shows Claude and Codex stats when present
- Console summary now includes Claude/Codex counts and percentages

## Tests
- All 7 existing detection assertions updated for new `{ tool, type }` return type
- 8 new Claude/Codex detection tests (bot author, assignee, reviewer, co-author trailer, false-positive guard)
- 2 new `writeToStepSummary` behavior tests for the env var control
- Fixed `import { jest }` missing in `step-summary.test.js` for ESM compatibility