### PR TITLE
fix: pin workflow dependencies to commit SHAs

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -7,7 +7,7 @@ permissions:
 
 jobs:
   actionlint:
-    uses: devops-actions/.github/.github/workflows/actionlint.yml@main
+    uses: devops-actions/.github/.github/workflows/actionlint.yml@0dd4a593cd45ebdb3a33e1ddd8ac23afe8e78c3c # main
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/actions-example-checker.yml
+++ b/.github/workflows/actions-example-checker.yml
@@ -7,6 +7,6 @@ permissions:
 
 jobs:
   validate-examples:
-    uses: devops-actions/.github/.github/workflows/actions-example-checker.yml@main
+    uses: devops-actions/.github/.github/workflows/actions-example-checker.yml@0dd4a593cd45ebdb3a33e1ddd8ac23afe8e78c3c # main
     permissions:
       contents: read

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   dependency-review:
-    uses: devops-actions/.github/.github/workflows/dependency-review.yml@main
+    uses: devops-actions/.github/.github/workflows/dependency-review.yml@0dd4a593cd45ebdb3a33e1ddd8ac23afe8e78c3c # main
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/example.yml
+++ b/.github/workflows/example.yml
@@ -51,7 +51,7 @@ jobs:
             http-cache-
       
       - name: Run PR analysis with charts
-        uses: devops-actions/github-copilot-pr-analysis@v0.0.5
+        uses: devops-actions/github-copilot-pr-analysis@0438ddce4697f8875d4d6b4eca03c4ef454a887b # v0.0.5
         with:
           github_token: ${{ secrets.GH_PAT }}
           output_format: ${{ inputs.output_format || 'json' }}
@@ -63,7 +63,7 @@ jobs:
           #   partial-org:include:repo1,repo2
       
       - name: Upload analysis results
-        uses: actions/upload-artifact@v7.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()
         with:
           name: pr-analysis-results-${{ github.run_number }}


### PR DESCRIPTION
## Summary

Resolves 5 open OSSF Scorecard **PinnedDependencies** code scanning alerts (#33–#37) by pinning all workflow action/reusable-workflow references to their exact commit SHAs.

## Changes

| File | Action pinned | SHA |
|------|--------------|-----|
| `.github/workflows/actionlint.yml` | `devops-actions/.github` workflow | `0dd4a593` |
| `.github/workflows/actions-example-checker.yml` | `devops-actions/.github` workflow | `0dd4a593` |
| `.github/workflows/dependency-review.yml` | `devops-actions/.github` workflow | `0dd4a593` |
| `.github/workflows/example.yml` | `devops-actions/github-copilot-pr-analysis@v0.0.5` | `0438ddce` |
| `.github/workflows/example.yml` | `actions/upload-artifact@v7.0.1` | `043fb46d` |

All original version tags are preserved as inline comments for readability.