### PR TITLE
feat: add detected AI tool breakdown chart (Copilot / Claude / Codex)

### DIFF
--- a/src/mermaid-generator.js
+++ b/src/mermaid-generator.js
@@ -949,6 +949,155 @@ export function generateSummaryStats(results) {
 }
 
 /**
+ * Determine which AI agents have at least one PR in the overall results.
+ * Returns an array of { name, total } objects, sorted by total descending.
+ */
+export function getActiveAgents(results) {
+    const agents = [
+        { name: 'GitHub Copilot', total: results.totalCopilotPRs || 0 },
+        { name: 'Claude',         total: results.totalClaudePRs  || 0 },
+        { name: 'Codex',          total: results.totalCodexPRs   || 0 },
+    ];
+    return agents.filter(a => a.total > 0).sort((a, b) => b.total - a.total);
+}
+
+/**
+ * Generate a mermaid pie chart showing the overall distribution of
+ * AI-assisted PRs by detected tool. Only includes agents with > 0 PRs.
+ */
+export function generateCodingAgentPieChart(results) {
+    const agents = getActiveAgents(results);
+    if (agents.length < 2) {
+        return 'No multi-agent data available for pie chart';
+    }
+
+    const chartLines = [];
+    chartLines.push('```mermaid');
+    chartLines.push('pie title "AI Tool Distribution (All-time)"');
+    for (const agent of agents) {
+        chartLines.push(`    "${agent.name}" : ${agent.total}`);
+    }
+    chartLines.push('```');
+
+    return chartLines.join('\n');
+}
+
+/**
+ * Generate a mermaid bar chart showing detected AI tool usage per week.
+ * Only includes weeks where at least one AI-assisted PR exists.
+ */
+export function generateCodingAgentWeeklyChart(weeklyData, results) {
+    if (!weeklyData || Object.keys(weeklyData).length === 0) {
+        return 'No data available for coding agent weekly chart';
+    }
+
+    const activeAgents = getActiveAgents(results);
+    if (activeAgents.length < 2) {
+        return 'No multi-agent data available for weekly chart';
+    }
+
+    // Sort weeks chronologically and keep only weeks with any AI-assisted PRs
+    const sortedWeeks = Object.keys(weeklyData)
+        .sort((a, b) => {
+            const [yearA, weekA] = parseWeekKey(a);
+            const [yearB, weekB] = parseWeekKey(b);
+            return yearA !== yearB ? yearA - yearB : weekA - weekB;
+        })
+        .filter(week =>
+            (weeklyData[week].copilotAssistedPRs || 0) > 0 ||
+            (weeklyData[week].claudeAssistedPRs   || 0) > 0 ||
+            (weeklyData[week].codexAssistedPRs    || 0) > 0
+        );
+
+    if (sortedWeeks.length === 0) {
+        return 'No AI-assisted PR data available for weekly chart';
+    }
+
+    const agentDataMap = {
+        'GitHub Copilot': week => weeklyData[week].copilotAssistedPRs || 0,
+        'Claude':         week => weeklyData[week].claudeAssistedPRs   || 0,
+        'Codex':          week => weeklyData[week].codexAssistedPRs    || 0,
+    };
+
+    const maxValue = Math.max(
+        ...sortedWeeks.flatMap(week =>
+            activeAgents.map(a => agentDataMap[a.name](week))
+        )
+    );
+
+    const chartLines = [];
+    chartLines.push('```mermaid');
+    chartLines.push('xychart-beta');
+    chartLines.push('    title "Detected AI Tool Usage by Week"');
+    chartLines.push('    x-axis [' + sortedWeeks.map(w => `"${formatWeekForDisplay(w)}"`).join(', ') + ']');
+    chartLines.push('    y-axis "Number of PRs" 0 --> ' + (maxValue + 2));
+
+    for (const agent of activeAgents) {
+        const values = sortedWeeks.map(w => agentDataMap[agent.name](w));
+        chartLines.push(`    bar "${agent.name}" [` + values.join(', ') + ']');
+    }
+
+    chartLines.push('```');
+
+    const legendLines = [
+        '',
+        '**Legend:**',
+        ...activeAgents.map(a => `- **${a.name}**: PRs where ${a.name} was the detected AI tool`),
+        '- *Note: each PR is attributed to one AI tool only*',
+    ];
+
+    return chartLines.concat(legendLines).join('\n');
+}
+
+/**
+ * Generate a markdown table showing the weekly breakdown of AI tool usage.
+ */
+export function generateCodingAgentDataTable(weeklyData, results) {
+    if (!weeklyData || Object.keys(weeklyData).length === 0) {
+        return 'No data available for coding agent table';
+    }
+
+    const activeAgents = getActiveAgents(results);
+    if (activeAgents.length < 2) {
+        return 'No multi-agent data available for table';
+    }
+
+    const agentDataMap = {
+        'GitHub Copilot': week => weeklyData[week].copilotAssistedPRs || 0,
+        'Claude':         week => weeklyData[week].claudeAssistedPRs   || 0,
+        'Codex':          week => weeklyData[week].codexAssistedPRs    || 0,
+    };
+
+    const sortedWeeks = Object.keys(weeklyData).sort((a, b) => {
+        const [yearA, weekA] = parseWeekKey(a);
+        const [yearB, weekB] = parseWeekKey(b);
+        return yearA !== yearB ? yearA - yearB : weekA - weekB;
+    });
+
+    const agentHeaders = activeAgents.map(a => a.name).join(' | ');
+    const agentSeps    = activeAgents.map(() => '---------').join('|');
+    const lines = [];
+    lines.push(`| Week | Total PRs | ${agentHeaders} |`);
+    lines.push(`|------|-----------|${agentSeps}|`);
+
+    for (const week of sortedWeeks) {
+        const data = weeklyData[week];
+        const totalAI = activeAgents.reduce((sum, a) => sum + agentDataMap[a.name](week), 0);
+        if (totalAI === 0) continue;
+
+        const agentCols = activeAgents.map(a => {
+            const count = agentDataMap[a.name](week);
+            const pct = totalAI > 0 ? Math.round(count / totalAI * 100) : 0;
+            return `${count} (${pct}%)`;
+        }).join(' | ');
+
+        lines.push(`| ${week} | ${data.totalPRs} | ${agentCols} |`);
+    }
+
+    return lines.join('\n');
+}
+
+/**
  * Write content to GitHub step summary.
  * Skips writing if OUTPUT_TO_STEP_SUMMARY is explicitly set to 'false'.
  */
@@ -1122,7 +1271,31 @@ export async function generateMermaidCharts() {
             await writeToStepSummary('');
             await writeToStepSummary('</details>');
         }
-        
+
+        // Generate coding agent breakdown (only when ≥ 2 different AI tools detected)
+        const activeAgents = getActiveAgents(results);
+        if (activeAgents.length >= 2) {
+            await writeToStepSummary('');
+            await writeToStepSummary('## 🤖 Detected AI Tool per PR');
+            await writeToStepSummary('');
+            await writeToStepSummary('*Each PR is attributed to the primary AI tool detected. Weeks with no AI-assisted PRs are excluded.*');
+
+            const agentPieChart = generateCodingAgentPieChart(results);
+            await writeToStepSummary(agentPieChart);
+
+            const agentWeeklyChart = generateCodingAgentWeeklyChart(weeklyData, results);
+            await writeToStepSummary('');
+            await writeToStepSummary(agentWeeklyChart);
+
+            const agentDataTable = generateCodingAgentDataTable(weeklyData, results);
+            await writeToStepSummary('<details>');
+            await writeToStepSummary('<summary>📊 AI Tool Usage Data</summary>');
+            await writeToStepSummary('');
+            await writeToStepSummary(agentDataTable);
+            await writeToStepSummary('');
+            await writeToStepSummary('</details>');
+        }
+
         console.log('Mermaid charts generated successfully!');
         
     } catch (error) {

--- a/tests/step-summary.test.js
+++ b/tests/step-summary.test.js
@@ -1,5 +1,5 @@
 import { jest } from '@jest/globals';
-import { generateSummaryStats, generateRepositoryDataTable, generateActionsMinutesChart, generateActionsMinutesDataTable, formatNumberMetric, writeToStepSummary } from '../src/mermaid-generator.js';
+import { generateSummaryStats, generateRepositoryDataTable, generateActionsMinutesChart, generateActionsMinutesDataTable, formatNumberMetric, writeToStepSummary, getActiveAgents, generateCodingAgentPieChart, generateCodingAgentWeeklyChart, generateCodingAgentDataTable } from '../src/mermaid-generator.js';
 
 describe('Step Summary Integration', () => {
     describe('formatNumberMetric', () => {
@@ -336,6 +336,131 @@ describe('Step Summary Integration', () => {
             
             expect(consoleSpy).toHaveBeenCalledWith('step summary content');
             consoleSpy.mockRestore();
+        });
+    });
+
+    // ─── Coding-agent charts ───────────────────────────────────────────────
+
+    describe('getActiveAgents', () => {
+        test('returns only agents with PRs, sorted descending', () => {
+            const results = { totalCopilotPRs: 318, totalClaudePRs: 3, totalCodexPRs: 0 };
+            const agents = getActiveAgents(results);
+            expect(agents).toHaveLength(2);
+            expect(agents[0].name).toBe('GitHub Copilot');
+            expect(agents[0].total).toBe(318);
+            expect(agents[1].name).toBe('Claude');
+        });
+
+        test('returns empty array when no AI PRs exist', () => {
+            expect(getActiveAgents({ totalCopilotPRs: 0 })).toHaveLength(0);
+        });
+
+        test('defaults missing fields to 0', () => {
+            const agents = getActiveAgents({});
+            expect(agents).toHaveLength(0);
+        });
+    });
+
+    describe('generateCodingAgentPieChart', () => {
+        test('returns fallback when fewer than 2 agents active', () => {
+            const result = generateCodingAgentPieChart({ totalCopilotPRs: 10, totalClaudePRs: 0, totalCodexPRs: 0 });
+            expect(result).toContain('No multi-agent data');
+        });
+
+        test('generates pie chart with active agents only', () => {
+            const result = generateCodingAgentPieChart({ totalCopilotPRs: 318, totalClaudePRs: 3, totalCodexPRs: 0 });
+            expect(result).toContain('```mermaid');
+            expect(result).toContain('pie title');
+            expect(result).toContain('"GitHub Copilot" : 318');
+            expect(result).toContain('"Claude" : 3');
+            expect(result).not.toContain('Codex');
+        });
+
+        test('handles all three agents', () => {
+            const result = generateCodingAgentPieChart({ totalCopilotPRs: 50, totalClaudePRs: 3, totalCodexPRs: 2 });
+            expect(result).toContain('"GitHub Copilot" : 50');
+            expect(result).toContain('"Claude" : 3');
+            expect(result).toContain('"Codex" : 2');
+        });
+    });
+
+    describe('generateCodingAgentWeeklyChart', () => {
+        const results = { totalCopilotPRs: 20, totalClaudePRs: 3, totalCodexPRs: 0 };
+
+        const weeklyData = {
+            '2025-W01': { copilotAssistedPRs: 10, claudeAssistedPRs: 2, codexAssistedPRs: 0, totalPRs: 15 },
+            '2025-W02': { copilotAssistedPRs: 0,  claudeAssistedPRs: 0, codexAssistedPRs: 0, totalPRs: 5  },
+            '2025-W03': { copilotAssistedPRs: 10, claudeAssistedPRs: 1, codexAssistedPRs: 0, totalPRs: 12 },
+        };
+
+        test('returns fallback when fewer than 2 agents active', () => {
+            const r = generateCodingAgentWeeklyChart(weeklyData, { totalCopilotPRs: 5, totalClaudePRs: 0, totalCodexPRs: 0 });
+            expect(r).toContain('No multi-agent data');
+        });
+
+        test('excludes all-zero weeks', () => {
+            const result = generateCodingAgentWeeklyChart(weeklyData, results);
+            expect(result).not.toContain('"25/02"');
+        });
+
+        test('includes weeks with AI-assisted PRs', () => {
+            const result = generateCodingAgentWeeklyChart(weeklyData, results);
+            expect(result).toContain('"25/01"');
+            expect(result).toContain('"25/03"');
+        });
+
+        test('emits correct bar counts', () => {
+            const result = generateCodingAgentWeeklyChart(weeklyData, results);
+            expect(result).toContain('bar "GitHub Copilot" [10, 10]');
+            expect(result).toContain('bar "Claude" [2, 1]');
+        });
+
+        test('includes single-attribution note in legend', () => {
+            const result = generateCodingAgentWeeklyChart(weeklyData, results);
+            expect(result).toContain('attributed to one AI tool only');
+        });
+
+        test('handles missing claude/codex fields gracefully', () => {
+            const sparse = {
+                '2025-W01': { copilotAssistedPRs: 5, totalPRs: 10 },
+                '2025-W02': { copilotAssistedPRs: 3, totalPRs: 8  },
+            };
+            const r = { totalCopilotPRs: 8, totalClaudePRs: 2, totalCodexPRs: 0 };
+            // Should not throw even though claudeAssistedPRs is undefined on each week
+            expect(() => generateCodingAgentWeeklyChart(sparse, r)).not.toThrow();
+        });
+    });
+
+    describe('generateCodingAgentDataTable', () => {
+        const results = { totalCopilotPRs: 20, totalClaudePRs: 3, totalCodexPRs: 0 };
+
+        const weeklyData = {
+            '2025-W01': { copilotAssistedPRs: 10, claudeAssistedPRs: 2, codexAssistedPRs: 0, totalPRs: 15 },
+            '2025-W02': { copilotAssistedPRs: 0,  claudeAssistedPRs: 0, codexAssistedPRs: 0, totalPRs: 5  },
+        };
+
+        test('returns fallback when fewer than 2 agents active', () => {
+            const r = generateCodingAgentDataTable(weeklyData, { totalCopilotPRs: 5 });
+            expect(r).toContain('No multi-agent data');
+        });
+
+        test('skips all-zero weeks from table', () => {
+            const result = generateCodingAgentDataTable(weeklyData, results);
+            expect(result).not.toContain('2025-W02');
+        });
+
+        test('includes header row with active agent names', () => {
+            const result = generateCodingAgentDataTable(weeklyData, results);
+            expect(result).toContain('GitHub Copilot');
+            expect(result).toContain('Claude');
+            expect(result).not.toContain('Codex');
+        });
+
+        test('shows count and percentage for each agent', () => {
+            const result = generateCodingAgentDataTable(weeklyData, results);
+            // Week 01: 10 Copilot + 2 Claude = 12 AI-assisted, Copilot ~83%, Claude ~17%
+            expect(result).toContain('10 (83%)');
+            expect(result).toContain('2 (17%)');
         });
     });
 });


### PR DESCRIPTION
## Summary

Adds a new **Detected AI Tool per PR** section to the step summary, showing the breakdown between GitHub Copilot, Claude, and Codex across all AI-assisted PRs.

Triggered by the observation that the rajbos/rajbos analysis run already tracks Claude (3 PRs) and Codex (2 PRs) alongside Copilot (318 PRs), but there was no visual representation of the agent mix.

## New charts

- Pie chart: overall all-time distribution of AI-assisted PRs by detected tool
- Bar chart: weekly breakdown (weeks with zero AI-assisted PRs are excluded)
- Data table: weekly count + percentage per agent (collapsed under details)

## Behaviour

- Section only appears when 2+ different AI tools have at least one PR — keeps output clean for single-tool setups.
- Each PR is attributed to exactly one AI tool (matches existing single-label detection); a note in the legend makes this explicit.
- All Claude/Codex fields default to 0 so older JSON files are handled gracefully.

## Files changed

- src/mermaid-generator.js — four new exports + generateMermaidCharts wired up
- tests/step-summary.test.js — 16 new tests