### PR TITLE
feat: add npm CLI package for org PR analysis with JSON output

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,55 @@
+# Copilot Coding Instructions
+
+## Project overview
+
+This is a **Node.js ESM project** that ships both as a GitHub Action (`action.yml`) and as an npm CLI package (`@rajbos/github-copilot-pr-analysis`).
+
+It analyzes pull requests across GitHub organizations or user accounts and reports Copilot, Claude, and Codex usage patterns with weekly breakdown and optional Mermaid chart generation.
+
+## Tech stack
+
+- **Runtime**: Node.js ≥ 20, ES Modules (`"type": "module"`)
+- **Key dependencies**: `axios` (HTTP), `node-cache` (caching), `commander` (CLI), `csv-writer`, `glob`
+- **Testing**: Jest with `--experimental-vm-modules` — run tests with `node --experimental-vm-modules node_modules/jest-cli/bin/jest.js`
+- **Linting**: ESLint — run with `npm run lint`
+
+## File layout
+
+| Path | Purpose |
+|------|---------|
+| `src/index.js` | GitHub Action / `npm run analyze` entry point |
+| `src/cli.js` | npm CLI entry (`copilot-pr-analysis` binary) |
+| `src/pr-analyzer.js` | Core `GitHubPRAnalyzer` class |
+| `src/mermaid-generator.js` | Mermaid chart generation |
+| `src/constants.js` | Shared constants (e.g. `REPORT_FOLDER`) |
+| `tests/` | Jest test suites |
+| `action.yml` | GitHub Action definition |
+| `skipped_orgs.txt` | Default org-skip config |
+
+## Coding conventions
+
+- Use `export` / `import` (ESM) — never `require`.
+- All user-visible log/status output goes to `console.log` (or `console.error` for errors). In the CLI (`src/cli.js`) these are redirected to `stderr` so stdout remains clean JSON.
+- The `GitHubPRAnalyzer` constructor signature: `(token, owner, repo = null, isOrg = false)`.  
+  Pass `isOrg: true` to use the `/orgs/{org}/repos` GitHub API endpoint.
+- Cache keys follow the pattern `<resource>_<owner>_<page>`.
+- Retry logic with exponential backoff is centralised in `_makeApiRequestWithRetry`.
+- Private repository names are masked in CI environments (see `maskPrivateRepoName`).
+
+## Running locally
+
+```bash
+GH_PAT=ghp_xxx npm run analyze          # full analysis, writes to report/
+GH_PAT=ghp_xxx npm run charts           # generate Mermaid charts
+
+# CLI (after npm install -g or via npx)
+copilot-pr-analysis my-org --token ghp_xxx
+```
+
+## Testing
+
+```bash
+node --experimental-vm-modules node_modules/jest-cli/bin/jest.js
+```
+
+One pre-existing failure exists in `tests/api-retry-integration.test.js` (bracket formatting mismatch) — do not worry about it unless you are fixing that specific test.

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,46 @@
+name: Publish to npm
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry run (do not actually publish)'
+        required: false
+        default: 'false'
+
+permissions:
+  contents: read
+  id-token: write   # needed for npm provenance
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@6c439dc8bdd0c9e700db98a04ae5cdcfe54855f0 # v2
+        with:
+          egress-policy: audit
+
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Publish to npm
+        run: |
+          if [ "${{ github.event.inputs.dry_run }}" = "true" ]; then
+            npm publish --dry-run
+          else
+            npm publish --provenance
+          fi
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,3 @@
+# Agent Instructions
+
+See [.github/copilot-instructions.md](.github/copilot-instructions.md) for full coding instructions and project conventions.

--- a/README.md
+++ b/README.md
@@ -27,7 +27,40 @@ A GitHub Action that analyzes pull requests across your repositories to track Gi
 
 ## Usage
 
-### Basic Usage
+### CLI (npm package)
+
+Run directly against any GitHub organization or user without a workflow:
+
+```bash
+# Using npx (no install required)
+GH_PAT=ghp_yourtoken npx github-copilot-pr-analysis my-org
+
+# Or install globally
+npm install -g github-copilot-pr-analysis
+copilot-pr-analysis my-org --token ghp_yourtoken
+
+# Analyze a user account instead of an org
+copilot-pr-analysis rajbos --type user --token ghp_yourtoken
+
+# Analyze a single repository
+copilot-pr-analysis my-org --repo my-repo --token ghp_yourtoken
+
+# Pipe JSON output for further processing
+copilot-pr-analysis my-org --token ghp_yourtoken > results.json
+copilot-pr-analysis my-org --token ghp_yourtoken | jq '.totalPRs'
+```
+
+All progress and status messages are written to `stderr`; only the raw JSON result is written to `stdout`.
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--token, -t` | GitHub PAT (or set `GH_PAT` / `GITHUB_TOKEN` env var) | — |
+| `--repo, -r` | Analyze a single repository | all repos |
+| `--type` | Account type: `org` or `user` | `org` |
+
+### Basic Usage (GitHub Actions)
 
 Add this action to your workflow to analyze all repositories:
 

--- a/package.json
+++ b/package.json
@@ -1,12 +1,21 @@
 {
-  "name": "github-copilot-pr-analysis",
+  "name": "@rajbos/github-copilot-pr-analysis",
   "version": "1.0.0",
-  "description": "GitHub Action to analyze GitHub PR's for Copilot usage",
+  "description": "GitHub Action and CLI to analyze GitHub PRs for Copilot usage",
   "main": "src/index.js",
   "bin": {
     "copilot-pr-analysis": "src/cli.js"
   },
   "type": "module",
+  "files": [
+    "src/",
+    "README.md",
+    "LICENSE",
+    "action.yml"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/devops-actions/github-copilot-pr-analysis.git"
@@ -25,7 +34,8 @@
     "analysis",
     "copilot",
     "automation",
-    "github-actions"
+    "github-actions",
+    "cli"
   ],
   "author": "devops-actions",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "1.0.0",
   "description": "GitHub Action to analyze GitHub PR's for Copilot usage",
   "main": "src/index.js",
+  "bin": {
+    "copilot-pr-analysis": "src/cli.js"
+  },
   "type": "module",
   "repository": {
     "type": "git",

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,0 +1,41 @@
+#!/usr/bin/env node
+
+import { Command } from 'commander';
+import { GitHubPRAnalyzer } from './pr-analyzer.js';
+
+// Redirect console.log to stderr so stdout carries only JSON output
+const originalLog = console.log;
+console.log = (...args) => process.stderr.write(args.join(' ') + '\n');
+
+const program = new Command();
+
+program
+    .name('copilot-pr-analysis')
+    .description('Analyze GitHub PRs for Copilot usage and output raw JSON')
+    .version('1.0.0')
+    .argument('<org>', 'GitHub organization or user name to analyze')
+    .option('-t, --token <token>', 'GitHub personal access token (defaults to GH_PAT or GITHUB_TOKEN env var)')
+    .option('-r, --repo <repo>', 'Analyze a single repository instead of all repos')
+    .option('--type <type>', 'Account type: "org" or "user"', 'org')
+    .action(async (org, options) => {
+        const token = options.token || process.env.GH_PAT || process.env.GITHUB_TOKEN;
+
+        if (!token) {
+            process.stderr.write('Error: GitHub token is required. Provide --token or set GH_PAT / GITHUB_TOKEN.\n');
+            process.exit(1);
+        }
+
+        const isOrg = options.type !== 'user';
+        const analyzer = new GitHubPRAnalyzer(token, org, options.repo || null, isOrg);
+
+        try {
+            const results = await analyzer.analyzePullRequests();
+            // Write clean JSON to stdout
+            process.stdout.write(JSON.stringify(results, null, 2) + '\n');
+        } catch (error) {
+            process.stderr.write(`Error: ${error.message}\n`);
+            process.exit(1);
+        }
+    });
+
+program.parse();

--- a/src/pr-analyzer.js
+++ b/src/pr-analyzer.js
@@ -55,10 +55,11 @@ export function shouldSkipRepository(repoData) {
  * GitHub Pull Request Analyzer for detecting Copilot collaboration.
  */
 export class GitHubPRAnalyzer {
-    constructor(token, owner, repo = null) {
+    constructor(token, owner, repo = null, isOrg = false) {
         this.token = token;
         this.owner = owner;
         this.repo = repo;
+        this.isOrg = isOrg;
         this.headers = {
             'Authorization': `token ${token}`,
             'Accept': 'application/vnd.github.v3+json'
@@ -276,12 +277,13 @@ export class GitHubPRAnalyzer {
         const repos = [];
         let page = 1;
         const perPage = 100;
+        const endpoint = this.isOrg ? `/orgs/${this.owner}/repos` : `/users/${this.owner}/repos`;
         
         while (true) {
             const cacheKey = `repos_${this.owner}_${page}`;
             try {
                 const response = await this._makeApiRequestWithRetry(
-                    () => this.api.get(`/users/${this.owner}/repos`, {
+                    () => this.api.get(endpoint, {
                         params: {
                             type: 'all',
                             sort: 'updated',


### PR DESCRIPTION
## Summary

Adds a `copilot-pr-analysis` CLI binary to the npm package so users can run analysis against any GitHub org or user directly from the command line and receive raw JSON on stdout.

## Changes

- **`src/cli.js`** (new): Dedicated CLI entry point
  - Accepts `<org>` as a positional argument
  - `--token` flag (or `GH_PAT` / `GITHUB_TOKEN` env vars)
  - `--repo` for single-repo analysis
  - `--type org|user` (default: `org`) to pick the right GitHub API endpoint
  - All `console.log` progress output → `stderr`; clean JSON → `stdout`

- **`package.json`**: Added `bin: { "copilot-pr-analysis": "src/cli.js" }`

- **`src/pr-analyzer.js`**: Added optional `isOrg` constructor param; `getUserRepositories` now uses `/orgs/{org}/repos` when `isOrg=true` (proper endpoint for organization repositories)

- **`README.md`**: New CLI usage section with examples

## Usage

```bash
# Run with npx
GH_PAT=ghp_xxx npx github-copilot-pr-analysis my-org

# Pipe to jq
copilot-pr-analysis my-org --token ghp_xxx | jq '.totalPRs'

# Single repo
copilot-pr-analysis my-org --repo my-repo --token ghp_xxx

# User account
copilot-pr-analysis rajbos --type user --token ghp_xxx
```

## Notes

- Pre-existing test failure in `api-retry-integration.test.js` (bracket formatting mismatch) is unrelated to these changes — confirmed by checking against `main`.