### PR TITLE
chore: bump secure-inputs reusable workflow pin

### DIFF
--- a/.github/workflows/secure-inputs.yml
+++ b/.github/workflows/secure-inputs.yml
@@ -21,6 +21,6 @@ permissions:
 
 jobs:
   scan-inputs:
-    uses: devops-actions/.github/.github/workflows/secure-inputs.yml@3bb5c8505eb368f90cf87956f0cc4d84cb8554d1 # main
+    uses: devops-actions/.github/.github/workflows/secure-inputs.yml@3bb5c8505eb368f90cf87956f0cc4d84cb8554d1 # v1.1.0
     permissions:
       contents: read

--- a/.github/workflows/secure-inputs.yml
+++ b/.github/workflows/secure-inputs.yml
@@ -21,6 +21,6 @@ permissions:
 
 jobs:
   scan-inputs:
-    uses: devops-actions/.github/.github/workflows/secure-inputs.yml@b77cea6d7ba1cd4e001581783cc592bbb63ce46d # main
+    uses: devops-actions/.github/.github/workflows/secure-inputs.yml@3bb5c8505eb368f90cf87956f0cc4d84cb8554d1 # main
     permissions:
       contents: read


### PR DESCRIPTION
Bumps the pinned SHA for the devops-actions/.github reusable workflow (secure-inputs.yml) to the latest main commit, which now pins secure-action-inputs to a tagged 1.0.0 release SHA instead of a floating @main ref (see devops-actions/.github#323).

Both devops-actions/.github and devops-actions/secure-action-inputs now have tagged releases, so Dependabot will also be able to auto-update this pin going forward.
