### PR TITLE
chore: group github-actions dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,10 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
 
   - package-ecosystem: npm
     directory: /


### PR DESCRIPTION
Adds a \groups.github-actions\ entry (pattern \*\) to the github-actions ecosystem update(s) in dependabot.yml, so future action version bumps are batched into a single PR instead of one per action.